### PR TITLE
ignore PROGRESS columns

### DIFF
--- a/_data/site_config.yml
+++ b/_data/site_config.yml
@@ -116,7 +116,8 @@ header_language_toggle: dropdown
 hide_empty_metadata: true
 hide_single_series: true
 hide_single_unit: true
-ignored_disaggregations: []
+ignored_disaggregations: 
+  - PROGRESS
 indicator_config_form:
   enabled: true
   dropdowns: []


### PR DESCRIPTION
See if it is possible to hide data in PROGRESS columns for use in transformations and conversions related to progress measure calculations.

Edit: PROGRESS column data is successfully hidden on the data hub while still remaining accessible for progress measure calculations!