### PR TITLE
ignore Progress column

### DIFF
--- a/_data/site_config.yml
+++ b/_data/site_config.yml
@@ -117,7 +117,7 @@ hide_empty_metadata: true
 hide_single_series: true
 hide_single_unit: true
 ignored_disaggregations: 
-  - PROGRESS
+  - Progress
 indicator_config_form:
   enabled: true
   dropdowns: []


### PR DESCRIPTION
Don't add a dropdown menu for the Progress column, if it exists.
Was previously ignoring `PROGRESS` column, now updated to ignore `Progress` column, following updates to the progress measure development in sdg-build.